### PR TITLE
Fixed missing INTERFACE_INCLUDE_DIRECTORIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,13 @@ configure_package_config_file(
   INSTALL_DESTINATION ${ConfigPackageLocation}
 )
 
+foreach(INSTALLED_LIBRARY ${INSTALLED_LIBRARIES})
+    target_include_directories(${INSTALLED_LIBRARY} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>
+        $<INSTALL_INTERFACE:include>
+    )
+endforeach()
+
 install(TARGETS ${INSTALLED_LIBRARIES}
     EXPORT ${targets_export_name}
     LIBRARY DESTINATION lib COMPONENT Runtime


### PR DESCRIPTION
turns out that webp was using include_directories instead of target_include_directories, so the install generators couldn't pick up the include path when generating WebPTargets.cmake

It now looks like this:
```
# Create imported target WebP::webpdecoder
add_library(WebP::webpdecoder STATIC IMPORTED)

set_target_properties(WebP::webpdecoder PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "-lpthread;/usr/lib/x86_64-linux-gnu/libm.so"
)

# Create imported target WebP::webp
add_library(WebP::webp STATIC IMPORTED)

set_target_properties(WebP::webp PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "-lpthread;/usr/lib/x86_64-linux-gnu/libm.so"
)

# Create imported target WebP::webpdemux
add_library(WebP::webpdemux STATIC IMPORTED)

set_target_properties(WebP::webpdemux PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "WebP::webp"
)
```